### PR TITLE
Set min version of systeminformation at Synk approval level

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "^1.2.0",
-    "systeminformation": "^4.22.5",
+    "systeminformation": "^4.34.11",
     "tar": "^4.4.8",
     "url-parse": "^1.4.3",
     "whatwg-fetch": "^3.0.0"


### PR DESCRIPTION
### What does this PR do?
While this branch is already matching the 0.3.5 master branch of Lightstep's package, Synk is telling us that the latest minor or patch version being installed doesn't match their requirements.  This will ensure that we are using the most secure version.

<img width="877" alt="InVisionApp_harmony-api_package_json___Snyk" src="https://user-images.githubusercontent.com/6432329/109671043-ba159780-7b41-11eb-9fe2-dd13ccddcbf4.png">
